### PR TITLE
Update mapUserToObject to accept discriminator as string

### DIFF
--- a/src/Discord/Provider.php
+++ b/src/Discord/Provider.php
@@ -66,7 +66,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     {
         return (new User())->setRaw($user)->map([
             'id' => $user['id'],
-            'nickname' => sprintf('%s#%d', $user['username'], $user['discriminator']),
+            'nickname' => sprintf('%s#%s', $user['username'], $user['discriminator']),
             'name' => $user['username'],
             'email' => $user['email'],
             'avatar' => (is_null($user['avatar'])) ? null : sprintf('https://cdn.discordapp.com/avatars/%s/%s.jpg', $user['id'], $user['avatar']),


### PR DESCRIPTION
mapUserToObject function was removing the leading 0 from username "%s#%d" because it was being seen as an integer rather than a string.

